### PR TITLE
Add JSDoc comments to helper modules

### DIFF
--- a/modules/mysql.js
+++ b/modules/mysql.js
@@ -1,8 +1,20 @@
 "use strict";
 
+/**
+ * Factory for creating a MySQL connection instance.
+ * @module mysql
+ */
+
 const mysql = require("mysql");
 
+/**
+ * Provides access to the shared MySQL connection.
+ * @type {{connection: import("mysql").Connection}}
+ */
 const mysqlModule = ((mysql) => {
+    /**
+     * MySQL connection configured from environment variables.
+     */
     const connection = mysql.createConnection({
         host: process.env.RDS_HOST,
         user: process.env.RDS_USER,

--- a/modules/query.js
+++ b/modules/query.js
@@ -1,10 +1,25 @@
 "use strict";
 
+/**
+ * Database query helper functions.
+ * @module query
+ */
+
 const mysql = require("./mysql");
 const winston = require("./winston");
 
+/**
+ * Wraps access to MySQL using Promises.
+ * @type {{query: function(string, Array): Promise<*>}}
+ */
 const queryModule = ((mysql, winston) => {
 
+    /**
+     * Execute a SQL query using the shared connection.
+     * @param {string} strQuery SQL string to execute
+     * @param {Array} params Parameters for the query
+     * @returns {Promise<*>} resolves with the query results
+     */
     const query = (strQuery, params) => {
 
         winston.logger.info("Invoked query function with " + strQuery);

--- a/modules/service/wake.js
+++ b/modules/service/wake.js
@@ -1,10 +1,23 @@
 "use strict";
 
+/**
+ * Helper functions for waking up the database connection.
+ * @module wake
+ */
+
 const winston = require("./../winston");
 const query = require("./../query");
 
+/**
+ * Collection of wake up service methods.
+ * @type {{wakeUp: function(): Promise<*>}}
+ */
 const wakeModule = ((winston, query) => {
 
+    /**
+     * Executes a trivial query to keep the database awake.
+     * @returns {Promise<*>} resolves when the query completes
+     */
     const wakeUp =  () => {
         winston.logger.info("waking up");
         return query.query("select 1 as wake", []);

--- a/modules/winston.js
+++ b/modules/winston.js
@@ -1,9 +1,21 @@
 "use strict";
 
+/**
+ * Winston logger configuration wrapper.
+ * @module winston
+ */
+
 const winston = require("winston");
 
+/**
+ * Provides a preconfigured Winston logger instance.
+ * @type {{logger: import("winston").Logger}}
+ */
 const winstonModule = ((winston) => {
 
+    /**
+     * Application logger set to the "info" level.
+     */
     const logger = winston.createLogger({
         level: "info",
         format: winston.format.cli(),


### PR DESCRIPTION
## Summary
- document wake module and its wakeUp service
- add documentation to mysql connection helper
- annotate the winston logger wrapper
- document query module and exported query function

## Testing
- `npm install`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68812d1907548330ba42f2974d95140b