### PR TITLE
Fix log route response order and add test

### DIFF
--- a/routes/log.js
+++ b/routes/log.js
@@ -18,7 +18,7 @@ router.put("/", async (req, res, next) => {
         result = "success";
         httpCode = 200;
     }
-    res.json({status: result}).status(httpCode);
+    res.status(httpCode).json({ status: result });
 });
 
 module.exports = router;

--- a/test/logRoute.test.js
+++ b/test/logRoute.test.js
@@ -1,0 +1,35 @@
+const express = require('express');
+const request = require('supertest');
+const proxyquire = require('proxyquire');
+
+const winstonStub = { logger: { info: () => {}, error: () => {} } };
+
+async function runTests() {
+    const successStub = { putLog: async () => 1 };
+    const logRouterSuccess = proxyquire('../routes/log', {
+        './../modules/log': successStub,
+        './../modules/winston': winstonStub
+    });
+    const appSuccess = express();
+    appSuccess.use(express.json());
+    appSuccess.use('/', logRouterSuccess);
+    await request(appSuccess).put('/').send({}).expect(200);
+
+    const failStub = { putLog: async () => null };
+    const logRouterFail = proxyquire('../routes/log', {
+        './../modules/log': failStub,
+        './../modules/winston': winstonStub
+    });
+    const appFail = express();
+    appFail.use(express.json());
+    appFail.use('/', logRouterFail);
+    await request(appFail).put('/').send({}).expect(409);
+}
+
+runTests().then(() => {
+    console.log('Tests passed');
+}).catch(err => {
+    console.error('Tests failed');
+    console.error(err);
+    process.exit(1);
+});


### PR DESCRIPTION
## Summary
- return HTTP status before JSON body in `log` route
- add a small test verifying HTTP codes

## Testing
- `npm install`
- `node test/logRoute.test.js`

------
https://chatgpt.com/codex/tasks/task_e_688149e9bf7c8330b58dd2ae2cf6f1f2