### PR TITLE
Fix log insert error handling

### DIFF
--- a/modules/log.js
+++ b/modules/log.js
@@ -11,9 +11,10 @@ const logDao = require("./dao/logDao");
 const logModule = ((moment, dynamoDbModule, winston, logDao) => {
 
     /**
+     * Stores a speed test result.
      *
-     * @param request
-     * @returns {Promise<PromiseResult<D, E>>}
+     * @param request {object} speed test payload
+     * @returns {Promise<number>} insert id or 0 when an error occurs
      */
     const putLog = (request) => {
         winston.logger.info("Invoked function putLog");
@@ -39,7 +40,7 @@ const logModule = ((moment, dynamoDbModule, winston, logDao) => {
 
         let insertId = logDao.create(model).catch((err) => {
             winston.logger.error("error on execution: " + err);
-            insertId = 0;
+            return 0;
         });
 
         return insertId;

--- a/routes/log.js
+++ b/routes/log.js
@@ -14,7 +14,7 @@ router.put("/", async (req, res, next) => {
     let result = "fail";
     let httpCode = 409;
     winston.logger.info("promise resolved with insert id " + insertId);
-    if (insertId !== null) {
+    if (insertId !== 0) {
         result = "success";
         httpCode = 200;
     }


### PR DESCRIPTION
## Summary
- return `0` in `putLog` when `logDao.create` fails
- treat insert id `0` as failure in router
- clarify `putLog` JSDoc

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688149e163248330887710223cfbd217