### PR TITLE
Fix lint unused param

### DIFF
--- a/modules/query.js
+++ b/modules/query.js
@@ -25,7 +25,7 @@ const queryModule = ((mysql, winston) => {
         winston.logger.info("Invoked query function with " + strQuery);
 
         return new Promise((resolve, reject) => {
-            mysql.connection.query(strQuery, params, (error, results, fields) => {
+            mysql.connection.query(strQuery, params, (error, results) => {
                 winston.logger.info("Finished executing query");
                 if (error) {
                     winston.logger.error("Error executing query ");


### PR DESCRIPTION
## Summary
- remove unused `fields` argument in query.js
- run `npm run lint`

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688167531c68833098fe51882ac4566d