### PR TITLE
Fix eslint errors

### DIFF
--- a/app.js
+++ b/app.js
@@ -29,6 +29,7 @@ app.use(function (req, res, next) {
 });
 
 // error handler
+// eslint-disable-next-line no-unused-vars
 app.use(function (err, req, res, next) {
     debug("Fell into error handler: " + err);
     // set locals, only providing error in development

--- a/routes/index.js
+++ b/routes/index.js
@@ -4,7 +4,7 @@ const express = require("express");
 const router = express.Router();
 
 /* GET home page. */
-router.get("/", function (req, res, next) {
+router.get("/", function (req, res) {
     res.json({title: "Express"});
 });
 

--- a/routes/log.js
+++ b/routes/log.js
@@ -5,7 +5,7 @@ const router = express.Router();
 const logModule = require("./../modules/log");
 const winston = require("./../modules/winston");
 
-router.put("/", async (req, res, next) => {
+router.put("/", async (req, res) => {
 
     winston.logger.info("Invoked route with request: " + JSON.stringify(req.body));
 

--- a/routes/wake.js
+++ b/routes/wake.js
@@ -5,7 +5,7 @@ const wakeModule = require("./../modules/service/wake");
 
 const router = express.Router();
 /* GET home page. */
-router.get("/", function (req, res, next) {
+router.get("/", function (req, res) {
     let result = wakeModule.wakeUp();
 
     result.then((result) => {


### PR DESCRIPTION
## Summary
- remove unused `next` args from routes
- document ignoring `next` in error handler

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68816ce8c74483308aad345a2262b52d